### PR TITLE
Update docker for node developers

### DIFF
--- a/twake/backend/core/app/Configuration/Parameters.php.dist
+++ b/twake/backend/core/app/Configuration/Parameters.php.dist
@@ -28,7 +28,7 @@ class Parameters extends \Common\Configuration
             ],
             "db" => [
                 "driver" => "pdo_cassandra",
-                "host" => "scylladb",
+                "host" => ["scylladb", "scylladb2"],
                 "port" => 9042,
                 "dbname" => "twake",
                 "user" => "root",

--- a/twake/docker-compose.yml.dist
+++ b/twake/docker-compose.yml.dist
@@ -2,15 +2,19 @@ version: "2"
 
 services:
   scylladb:
-    image: scylladb/scylla
-    ports:
-      - 9180:9180
-      - 9100:9100
-      - 9160:9160
-      - 9042:9042
+    image: scylladb/scylla:4.1.0
+    command: --seeds=scylladb2 --smp 1 --memory 400M --overprovisioned 1 --api-address 0.0.0.0
     volumes:
       - ./docker-data/scylladb:/var/lib/scylla
-    command: "--experimental 1"
+    networks:
+      scylla:
+  scylladb2:
+    image: scylladb/scylla:4.1.0
+    command: --seeds=scylladb --smp 1 --memory 400M --overprovisioned 1 --api-address 0.0.0.0
+    volumes:
+      - ./docker-data/scylladb2:/var/lib/scylla
+    networks:
+      scylla:
   rabbitmq:
     image: rabbitmq:3
     environment:
@@ -85,3 +89,7 @@ services:
       - ./docker-data/logs/nginx/:/var/log/nginx
       - ./docker-data/drive-preview/:/twake-core/web/medias/
       - ./docker-data/uploads/:/twake-core/web/upload/
+
+networks:
+  scylla:
+    driver: bridge

--- a/twake/docker-compose.yml.dist.dev
+++ b/twake/docker-compose.yml.dist.dev
@@ -2,30 +2,25 @@ version: "2"
 
 services:
   scylladb:
-    image: scylladb/scylla
-    ports:
-      - 9180:9180
-      - 9100:9100
-      - 9160:9160
-      - 9042:9042
+    image: scylladb/scylla:4.1.0
+    command: --seeds=scylladb2 --smp 1 --memory 400M --overprovisioned 1 --api-address 0.0.0.0
     volumes:
       - ./docker-data/scylladb:/var/lib/scylla
-    command: "--experimental 1"
+    networks:
+      scylla:
+  scylladb2:
+    image: scylladb/scylla:4.1.0
+    command: --seeds=scylladb --smp 1 --memory 400M --overprovisioned 1 --api-address 0.0.0.0
+    volumes:
+      - ./docker-data/scylladb2:/var/lib/scylla
+    networks:
+      scylla:
   rabbitmq:
     image: rabbitmq:3
+    mem_limit: 300m
     environment:
       RABBITMQ_DEFAULT_USER: admin
       RABBITMQ_DEFAULT_PASS: admin
-    ports:
-      - 5672:5672
-      - 15672:15672
-  redis:
-    image: "redis:alpine"
-    command: redis-server --requirepass some_password
-    ports:
-      - "6379:6379"
-    environment:
-      - REDIS_REPLICATION_MODE=master
   node:
     image: twaketech/twake-node
     environment:
@@ -42,7 +37,6 @@ services:
       - scylladb
       - rabbitmq
       - elasticsearch
-      - redis
     links:
       - websockets
       - scylladb
@@ -78,14 +72,14 @@ services:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    mem_limit: 1g
     ulimits:
       memlock:
         soft: -1
         hard: -1
     volumes:
-      - ./docker-data/es_twake:/usr/share/elasticsearch/data
-    ports:
-      - 9200:9200
+      - ./docker-data/es:/usr/share/elasticsearch/data
+
   nginx:
     image: twaketech/twake-nginx
     environment:
@@ -108,3 +102,7 @@ services:
       - ./frontend/:/twake-react/
       - ./docker-data/drive-preview/:/twake-core/web/medias/
       - ./docker-data/uploads/:/twake-core/web/upload/
+
+networks:
+  scylla:
+    driver: bridge

--- a/twake/docker-compose.yml.dist.tests
+++ b/twake/docker-compose.yml.dist.tests
@@ -2,15 +2,19 @@ version: "2"
 
 services:
   scylladb:
-    image: scylladb/scylla
-    ports:
-      - 9180:9180
-      - 9100:9100
-      - 9160:9160
-      - 9042:9042
+    image: scylladb/scylla:4.1.0
+    command: --seeds=scylladb2 --smp 1 --memory 400M --overprovisioned 1 --api-address 0.0.0.0
     volumes:
       - ./docker-data/scylladb:/var/lib/scylla
-    command: "--experimental 1"
+    networks:
+      scylla:
+  scylladb2:
+    image: scylladb/scylla:4.1.0
+    command: --seeds=scylladb --smp 1 --memory 400M --overprovisioned 1 --api-address 0.0.0.0
+    volumes:
+      - ./docker-data/scylladb2:/var/lib/scylla
+    networks:
+      scylla:
   rabbitmq:
     image: rabbitmq:3
     environment:
@@ -85,3 +89,7 @@ services:
       - ./docker-data/logs/nginx/:/var/log/nginx
       - ./docker-data/letsencrypt/:/etc/letsencrypt/
       - ./frontend/:/twake-react/
+      
+networks:
+  scylla:
+    driver: bridge

--- a/twake/docker/twake-node/entrypoint.sh
+++ b/twake/docker/twake-node/entrypoint.sh
@@ -4,12 +4,14 @@ echo $1
 
 if [ "$1" = "dev" ]
 then
+  npm run build
   npm run watch
 else
   if test -f "/configuration/production.json"; then
     cp /configuration/* /twake-node/config/
   fi
 
+  npm run build
   npm run serve
 fi
 


### PR DESCRIPTION
Update the dockers, the new way of working with docker will be:

```
cd twake
cp docker-compose.yml.dev docker-compose.yml
docker-compose up -d
```

If you change your files, it will be updated on the docker simultaneously (watcher is on in dev mode).

To run tests or any commands:
```
docker-compose exec node npm run test
docker-compose exec node npm run lint
...
```

In the app default parameters, it will be necessary to update hosts. ScyllaDB is available through `["scylladb:9042", "scylladb2:9042"]` (two nodes).