### PR TITLE
#470 Introduce execution context in CRUD services

### DIFF
--- a/twake/backend/node/src/core/platform/framework/api/crud-service.ts
+++ b/twake/backend/node/src/core/platform/framework/api/crud-service.ts
@@ -1,4 +1,6 @@
 export class EntityTarget<Entity> {
+  context?: ExecutionContext;
+
   /**
    *
    * @param type type of entity
@@ -45,10 +47,17 @@ export declare type EntityId = string | number;
 
 export declare type EntityOperationResult<Entity> = CreateResult<Entity> | UpdateResult<Entity> | DeleteResult<Entity>;
 
+export interface ExecutionContext {
+  user: { id: string };
+  url: string;
+  method: string;
+  transport: "http" | "ws"
+}
+
 export interface CRUDService<Entity> {
-  create(item: Entity): Promise<CreateResult<Entity>>;
-  get(id: EntityId): Promise<Entity>;
-  update(id: EntityId, item: Entity, /* TODO: Options */): Promise<UpdateResult<Entity>>;
-  delete(id: EntityId): Promise<DeleteResult<Entity>>;
-  list(/* TODO: Options */): Promise<Entity[]>;
+  create(item: Entity, context?: ExecutionContext): Promise<CreateResult<Entity>>;
+  get(id: EntityId, context?: ExecutionContext): Promise<Entity>;
+  update(id: EntityId, item: Entity, context?: ExecutionContext,/* TODO: Options */): Promise<UpdateResult<Entity>>;
+  delete(id: EntityId, context?: ExecutionContext): Promise<DeleteResult<Entity>>;
+  list(context: ExecutionContext/* TODO: Options */): Promise<Entity[]>;
 }

--- a/twake/backend/node/src/core/platform/framework/decorators/realtime/created.ts
+++ b/twake/backend/node/src/core/platform/framework/decorators/realtime/created.ts
@@ -16,6 +16,8 @@ export function RealtimeCreated<T>(path: string | PathResolver<T>, resourcePath?
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     descriptor.value = async function(...args: any[]) {
       const result: CreateResult<T> = await originalMethod.apply(this, args);
+      // context should always be the last arg
+      const context = args && args[args.length -1];
 
       if (!(result instanceof CreateResult)) {
         return result;
@@ -23,8 +25,8 @@ export function RealtimeCreated<T>(path: string | PathResolver<T>, resourcePath?
 
       eventBus.publish<T>(RealtimeEntityActionType.Created, {
         type: result.type,
-        path: getPath(path, result),
-        resourcePath: getPath(resourcePath, result),
+        path: getPath(path, result, context),
+        resourcePath: getPath(resourcePath, result, context),
         entity: result.entity,
         result
       } as RealtimeEntityEvent<T> );

--- a/twake/backend/node/src/core/platform/framework/decorators/realtime/deleted.ts
+++ b/twake/backend/node/src/core/platform/framework/decorators/realtime/deleted.ts
@@ -16,6 +16,7 @@ export function RealtimeDeleted<T>(path: string | PathResolver<T>, resourcePath?
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     descriptor.value = async function(...args: any[]) {
       const result: DeleteResult<T> = await originalMethod.apply(this, args);
+      const context = args && args[args.length -1];
 
       if (!(result instanceof DeleteResult)) {
         return result;
@@ -23,8 +24,8 @@ export function RealtimeDeleted<T>(path: string | PathResolver<T>, resourcePath?
 
       result.deleted && eventBus.publish<T>(RealtimeEntityActionType.Deleted, {
         type: result.type,
-        path: getPath(path, result),
-        resourcePath: getPath(resourcePath, result),
+        path: getPath(path, result, context),
+        resourcePath: getPath(resourcePath, result, context),
         entity: result.entity,
         result
       } as RealtimeEntityEvent<T>);

--- a/twake/backend/node/src/core/platform/framework/decorators/realtime/index.ts
+++ b/twake/backend/node/src/core/platform/framework/decorators/realtime/index.ts
@@ -1,18 +1,18 @@
-import { EntityTarget } from "../../api/crud-service";
+import { EntityTarget, ExecutionContext } from "../../api/crud-service";
 
 export * from "./created";
 export * from "./deleted";
 export * from "./updated";
 
 export interface PathResolver<T> {
-  (type: T): string;
+  (type: T, context?: ExecutionContext): string;
 }
 
-export function getPath<T>(path : string | PathResolver<T> = "/", entity: EntityTarget<T>): string {
+export function getPath<T>(path : string | PathResolver<T> = "/", entity: EntityTarget<T>, context: ExecutionContext): string {
   let result;
 
   if (typeof path === "function") {
-    result = path(entity.entity);
+    result = path(entity.entity, context);
   } else {
     result = path;
   }

--- a/twake/backend/node/src/core/platform/framework/decorators/realtime/updated.ts
+++ b/twake/backend/node/src/core/platform/framework/decorators/realtime/updated.ts
@@ -16,6 +16,7 @@ export function RealtimeUpdated<T>(path: string | PathResolver<T>, resourcePath?
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     descriptor.value = async function(...args: any[]) {
       const result: UpdateResult<T> = await originalMethod.apply(this, args);
+      const context = args && args[args.length -1];
 
       if (!(result instanceof UpdateResult)) {
         return result;
@@ -23,8 +24,8 @@ export function RealtimeUpdated<T>(path: string | PathResolver<T>, resourcePath?
 
       eventBus.publish<T>(RealtimeEntityActionType.Updated, {
         type: result.type,
-        path: getPath(path, result),
-        resourcePath: getPath(resourcePath, result),
+        path: getPath(path, result, context),
+        resourcePath: getPath(resourcePath, result, context),
         entity: result.entity,
         result
       } as RealtimeEntityEvent<T>);

--- a/twake/backend/node/src/core/platform/services/webserver/types.ts
+++ b/twake/backend/node/src/core/platform/services/webserver/types.ts
@@ -1,0 +1,12 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+
+export interface CrudHandler<T> {
+  (request: FastifyRequest, reply?: FastifyReply): Promise<T>;
+}
+
+export interface CrudController<GetResponseType, SaveResponseType, ListResponseType, DeleteResponseType> {
+  get?: CrudHandler<GetResponseType>;
+  save?: CrudHandler<SaveResponseType>;
+  list?: CrudHandler<ListResponseType>;
+  delete?: CrudHandler<DeleteResponseType>;
+}

--- a/twake/backend/node/src/services/channels/realtime.ts
+++ b/twake/backend/node/src/services/channels/realtime.ts
@@ -1,3 +1,4 @@
+import { ExecutionContext } from "../../core/platform/framework/api/crud-service";
 import { User, Workspace, WebsocketMetadata } from "../types";
 import { Channel } from "./entities";
 
@@ -29,7 +30,9 @@ export function getPublicRoomName(workspace: Workspace): string {
   return `/companies/${workspace.company_id}/workspaces/${workspace.workspace_id}/channels?type=public`;
 }
 
-export function getChannelPath(channel: Channel): string {
+// TODO: The channel path depends on the execution context
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function getChannelPath(channel: Channel, context?: ExecutionContext): string {
   return `${getChannelsPath()}/${channel.id}`;
 }
 

--- a/twake/backend/node/src/services/channels/realtime.ts
+++ b/twake/backend/node/src/services/channels/realtime.ts
@@ -1,6 +1,6 @@
-import { ExecutionContext } from "../../core/platform/framework/api/crud-service";
 import { User, Workspace, WebsocketMetadata } from "../types";
 import { Channel } from "./entities";
+import { WorkspaceExecutionContext } from "./types";
 
 export function getWebsocketInformation(channel: Channel): WebsocketMetadata {
   return {
@@ -27,15 +27,20 @@ export function getPrivateRoomName(workspace: Workspace, user: User): string {
 }
 
 export function getPublicRoomName(workspace: Workspace): string {
-  return `/companies/${workspace.company_id}/workspaces/${workspace.workspace_id}/channels?type=public`;
+  return `/companies/${workspace?.company_id}/workspaces/${workspace?.workspace_id}/channels?type=public`;
 }
 
-// TODO: The channel path depends on the execution context
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function getChannelPath(channel: Channel, context?: ExecutionContext): string {
-  return `${getChannelsPath()}/${channel.id}`;
+export function getRoomName(channel: Channel, context?: WorkspaceExecutionContext): string {
+  return getPublicRoomName(context.workspace);
 }
 
-export function getChannelsPath(): string {
-  return "/channels";
+export function getChannelPath(channel: Channel, context?: WorkspaceExecutionContext): string {
+  return `${getChannelsPath(context?.workspace)}/${channel.id}`;
+}
+
+export function getChannelsPath(workspace?: Workspace): string {
+  return workspace ?
+    `/companies/${workspace.company_id}/workspaces/${workspace.workspace_id}/channels`:
+    "/channels";
 }

--- a/twake/backend/node/src/services/channels/services/cassandra.ts
+++ b/twake/backend/node/src/services/channels/services/cassandra.ts
@@ -2,7 +2,6 @@
 import cassandra from "cassandra-driver";
 import { Channel } from "../entities";
 import ChannelServiceAPI from "../provider";
-import { RealtimeDeleted, RealtimeCreated, RealtimeUpdated } from "../../../core/platform/framework/decorators";
 import { UpdateResult, CreateResult, DeleteResult } from "../../../core/platform/framework/api/crud-service";
 
 export class CassandraChannelService implements ChannelServiceAPI {
@@ -10,7 +9,6 @@ export class CassandraChannelService implements ChannelServiceAPI {
 
   constructor(private client: cassandra.Client) {}
 
-  @RealtimeCreated<Channel>("/channels", channel => `/channels/${channel.id}`)
   create(channel: Channel): Promise<CreateResult<Channel>> {
     throw new Error("Not implemented");
   }
@@ -19,12 +17,10 @@ export class CassandraChannelService implements ChannelServiceAPI {
     throw new Error("Not implemented");
   }
 
-  @RealtimeUpdated<string>("/channels", id => `/channels/${id}`)
   async update(id: string, entity: Channel): Promise<UpdateResult<Channel>> {
     throw new Error("Not implemented");
   }
 
-  @RealtimeDeleted<Channel>("/channels", channel => `/channels/${channel.id}`)
   async delete(id: string): Promise<DeleteResult<Channel>> {
     throw new Error("Not implemented");
   }

--- a/twake/backend/node/src/services/channels/services/index.ts
+++ b/twake/backend/node/src/services/channels/services/index.ts
@@ -1,3 +1,5 @@
+import { RealtimeCreated, RealtimeUpdated, RealtimeDeleted } from "../../../core/platform/framework";
+import { CreateResult, UpdateResult, DeleteResult, ExecutionContext } from "../../../core/platform/framework/api/crud-service";
 import { MongoConnector } from "../../../core/platform/services/database/services/connectors/mongodb";
 import { CassandraConnector } from "../../../core/platform/services/database/services/connectors/cassandra";
 import { DatabaseServiceAPI } from "../../../core/platform/services/database/api";
@@ -5,16 +7,51 @@ import ChannelServiceAPI from "../provider";
 
 import { MongoChannelService } from "./mongo";
 import { CassandraChannelService } from "./cassandra";
+import { Channel } from "../entities";
+import { getChannelPath } from "../realtime";
 
 export function getService(databaseService: DatabaseServiceAPI): ChannelServiceAPI {
+  return new Service(getServiceInstance(databaseService));
+}
+
+function getServiceInstance(databaseService: DatabaseServiceAPI): ChannelServiceAPI {
   const type = databaseService.getConnector().getType();
 
   switch(type) {
     case "mongodb":
       return new MongoChannelService((databaseService.getConnector() as MongoConnector).getDatabase());
     case "cassandra":
-      throw new CassandraChannelService((databaseService.getConnector() as CassandraConnector).getClient());
+      return new CassandraChannelService((databaseService.getConnector() as CassandraConnector).getClient());
     default:
       throw new Error(`${type} service is not supported`);
+  }
+}
+
+class Service implements ChannelServiceAPI {
+  version: "1";
+
+  constructor(private service: ChannelServiceAPI) {}
+
+  @RealtimeCreated<Channel>("/channels", (channel, context) => getChannelPath(channel, context))
+  async create(channel: Channel, context: ExecutionContext): Promise<CreateResult<Channel>> {
+    return this.service.create(channel, context);
+  }
+
+  get(id: string, context: ExecutionContext): Promise<Channel> {
+    return this.service.get(id, context);
+  }
+
+  @RealtimeUpdated<Channel>("/channels", (channel, context) => getChannelPath(channel, context))
+  update(id: string, channel: Channel, context: ExecutionContext): Promise<UpdateResult<Channel>> {
+    return this.service.update(id, channel, context);
+  }
+
+  @RealtimeDeleted<Channel>("/channels", (channel, context) => getChannelPath(channel, context))
+  delete(id: string, context: ExecutionContext): Promise<DeleteResult<Channel>> {
+    return this.service.delete(id, context);
+  }
+
+  list(context: ExecutionContext): Promise<Channel[]> {
+    return this.service.list(context);
   }
 }

--- a/twake/backend/node/src/services/channels/services/index.ts
+++ b/twake/backend/node/src/services/channels/services/index.ts
@@ -1,5 +1,5 @@
 import { RealtimeCreated, RealtimeUpdated, RealtimeDeleted } from "../../../core/platform/framework";
-import { CreateResult, UpdateResult, DeleteResult, ExecutionContext } from "../../../core/platform/framework/api/crud-service";
+import { CreateResult, UpdateResult, DeleteResult } from "../../../core/platform/framework/api/crud-service";
 import { MongoConnector } from "../../../core/platform/services/database/services/connectors/mongodb";
 import { CassandraConnector } from "../../../core/platform/services/database/services/connectors/cassandra";
 import { DatabaseServiceAPI } from "../../../core/platform/services/database/api";
@@ -8,7 +8,8 @@ import ChannelServiceAPI from "../provider";
 import { MongoChannelService } from "./mongo";
 import { CassandraChannelService } from "./cassandra";
 import { Channel } from "../entities";
-import { getChannelPath } from "../realtime";
+import { getChannelPath, getRoomName } from "../realtime";
+import { WorkspaceExecutionContext } from "../types";
 
 export function getService(databaseService: DatabaseServiceAPI): ChannelServiceAPI {
   return new Service(getServiceInstance(databaseService));
@@ -32,26 +33,34 @@ class Service implements ChannelServiceAPI {
 
   constructor(private service: ChannelServiceAPI) {}
 
-  @RealtimeCreated<Channel>("/channels", (channel, context) => getChannelPath(channel, context))
-  async create(channel: Channel, context: ExecutionContext): Promise<CreateResult<Channel>> {
+  @RealtimeCreated<Channel>(
+    (channel, context) => getRoomName(channel, context as WorkspaceExecutionContext),
+    (channel, context) => getChannelPath(channel, context as WorkspaceExecutionContext)
+  )
+  async create(channel: Channel, context: WorkspaceExecutionContext): Promise<CreateResult<Channel>> {
     return this.service.create(channel, context);
   }
 
-  get(id: string, context: ExecutionContext): Promise<Channel> {
+  get(id: string, context: WorkspaceExecutionContext): Promise<Channel> {
     return this.service.get(id, context);
   }
 
-  @RealtimeUpdated<Channel>("/channels", (channel, context) => getChannelPath(channel, context))
-  update(id: string, channel: Channel, context: ExecutionContext): Promise<UpdateResult<Channel>> {
+  @RealtimeUpdated<Channel>(
+    (channel, context) => getRoomName(channel, context as WorkspaceExecutionContext),
+    (channel, context) => getChannelPath(channel, context as WorkspaceExecutionContext)
+  )
+  update(id: string, channel: Channel, context: WorkspaceExecutionContext): Promise<UpdateResult<Channel>> {
     return this.service.update(id, channel, context);
   }
 
-  @RealtimeDeleted<Channel>("/channels", (channel, context) => getChannelPath(channel, context))
-  delete(id: string, context: ExecutionContext): Promise<DeleteResult<Channel>> {
+  @RealtimeDeleted<Channel>(
+    (channel, context) => getRoomName(channel, context as WorkspaceExecutionContext),
+    (channel, context) => getChannelPath(channel, context as WorkspaceExecutionContext))
+  delete(id: string, context: WorkspaceExecutionContext): Promise<DeleteResult<Channel>> {
     return this.service.delete(id, context);
   }
 
-  list(context: ExecutionContext): Promise<Channel[]> {
+  list(context: WorkspaceExecutionContext): Promise<Channel[]> {
     return this.service.list(context);
   }
 }

--- a/twake/backend/node/src/services/channels/services/mongo.ts
+++ b/twake/backend/node/src/services/channels/services/mongo.ts
@@ -1,9 +1,7 @@
 import * as mongo from "mongodb";
 import { Channel } from "../entities";
 import ChannelServiceAPI from "../provider";
-import { RealtimeDeleted, RealtimeCreated, RealtimeUpdated } from "../../../core/platform/framework/decorators";
 import { UpdateResult, CreateResult, DeleteResult } from "../../../core/platform/framework/api/crud-service";
-import { getChannelPath } from "../realtime";
 
 export class MongoChannelService implements ChannelServiceAPI {
   version = "1";
@@ -13,7 +11,6 @@ export class MongoChannelService implements ChannelServiceAPI {
     this.collection = this.db.collection<Channel>("channels");
   }
 
-  @RealtimeCreated<Channel>("/channels", channel => getChannelPath(channel))
   async create(channel: Channel): Promise<CreateResult<Channel>> {
     const result = await this.collection.insertOne(channel, { w:1 });
 
@@ -37,21 +34,18 @@ export class MongoChannelService implements ChannelServiceAPI {
     return channel;
   }
 
-  @RealtimeUpdated<Channel>("/channels", channel => getChannelPath(channel))
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async update(id: string, entity: Channel): Promise<UpdateResult<Channel>> {
-    // TODO
-    return null;
+  async update(id: string, channel: Channel): Promise<UpdateResult<Channel>> {
+    return new UpdateResult("channel", { id } as Channel);
   }
 
-  @RealtimeDeleted<Channel>("/channels", channel => getChannelPath(channel))
   async delete(id: string): Promise<DeleteResult<Channel>> {
     const deleteResult = await this.collection.deleteOne({ _id: new mongo.ObjectID(id)});
 
     return new DeleteResult<Channel>("channel", { id } as Channel, deleteResult.deletedCount === 1);
   }
 
-  async list(/* TODO: Options */): Promise<Channel[]> {
+  async list(): Promise<Channel[]> {
     return this.collection.find().map(document => ({...document, ...{id: String(document._id)}})).toArray();
   }
 }

--- a/twake/backend/node/src/services/channels/types.ts
+++ b/twake/backend/node/src/services/channels/types.ts
@@ -1,0 +1,6 @@
+import { ExecutionContext } from "../../core/platform/framework/api/crud-service";
+import { Workspace } from "../types";
+
+export interface WorkspaceExecutionContext extends ExecutionContext {
+  workspace: Workspace;
+}

--- a/twake/backend/node/src/services/channels/web/controller.ts
+++ b/twake/backend/node/src/services/channels/web/controller.ts
@@ -1,21 +1,25 @@
 import { plainToClass } from "class-transformer";
 import { FastifyReply, FastifyRequest } from "fastify";
-import { ExecutionContext } from "../../../core/platform/framework/api/crud-service";
 import { CrudController } from "../../../core/platform/services/webserver/types";
 import { Channel } from "../entities";
 import ChannelServiceAPI from "../provider";
 import { getWebsocketInformation, getWorkspaceRooms } from "../realtime";
+import { WorkspaceExecutionContext } from "../types";
 import { BaseChannelsParameters, ChannelCreateResponse, ChannelDeleteResponse, ChannelGetResponse, ChannelListQueryParameters, ChannelListResponse, ChannelParameters, CreateChannelBody } from "./types";
 
 export class ChannelCrudController implements CrudController<ChannelGetResponse, ChannelCreateResponse, ChannelListResponse, ChannelDeleteResponse> {
   constructor(protected service: ChannelServiceAPI) {}
 
-  getExecutionContext(request: FastifyRequest): ExecutionContext {
+  getExecutionContext(request: FastifyRequest<{ Params: BaseChannelsParameters }>): WorkspaceExecutionContext {
     return {
       user: request.currentUser,
       url: request.url,
       method: request.routerMethod,
-      transport: "http"
+      transport: "http",
+      workspace: {
+        company_id: request.params.company_id,
+        workspace_id: request.params.workspace_id
+      }
     };
   }
 

--- a/twake/backend/node/src/services/channels/web/controller.ts
+++ b/twake/backend/node/src/services/channels/web/controller.ts
@@ -1,37 +1,82 @@
 import { plainToClass } from "class-transformer";
+import { FastifyReply, FastifyRequest } from "fastify";
+import { ExecutionContext } from "../../../core/platform/framework/api/crud-service";
+import { CrudController } from "../../../core/platform/services/webserver/types";
 import { Channel } from "../entities";
 import ChannelServiceAPI from "../provider";
-import { BaseChannelsParameters, ChannelListQueryParameters, ChannelParameters, CreateChannelBody } from "./types";
+import { getWebsocketInformation, getWorkspaceRooms } from "../realtime";
+import { BaseChannelsParameters, ChannelCreateResponse, ChannelDeleteResponse, ChannelGetResponse, ChannelListQueryParameters, ChannelListResponse, ChannelParameters, CreateChannelBody } from "./types";
 
-export default class ChannelController {
-  constructor(private service: ChannelServiceAPI) {}
+export class ChannelCrudController implements CrudController<ChannelGetResponse, ChannelCreateResponse, ChannelListResponse, ChannelDeleteResponse> {
+  constructor(protected service: ChannelServiceAPI) {}
 
-  async create(params: BaseChannelsParameters, channel: CreateChannelBody): Promise<Channel> {
+  getExecutionContext(request: FastifyRequest): ExecutionContext {
+    return {
+      user: request.currentUser,
+      url: request.url,
+      method: request.routerMethod,
+      transport: "http"
+    };
+  }
+
+  async get(request: FastifyRequest<{ Params: ChannelParameters }>, reply: FastifyReply): Promise<ChannelGetResponse> {
+    const resource = await this.service.get(request.params.id, this.getExecutionContext(request));
+
+    if (!resource) {
+      throw reply.notFound(`Channel ${request.params.id} not found`);
+    }
+
+    return {
+      websocket: getWebsocketInformation(resource),
+      resource
+    };
+  }
+
+  async save(request: FastifyRequest<{ Body: CreateChannelBody, Params: ChannelParameters }>, reply: FastifyReply): Promise<ChannelCreateResponse> {
     const entity = plainToClass(Channel, {
-      ...channel,
+      ...request.body,
       ...{
-        company_id: params.company_id,
-        workspace_id: params.workspace_id
+        company_id: request.params.company_id,
+        workspace_id: request.params.workspace_id
       }
     });
 
-    const result = await this.service.create(entity);
+    const result = await this.service.create(entity, this.getExecutionContext(request));
 
-    return result.entity;
+    if (result.entity) {
+      reply.code(201);
+    }
+
+    return {
+      websocket: getWebsocketInformation(result.entity),
+      resource: result.entity
+    };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async getChannels(params: BaseChannelsParameters, query: ChannelListQueryParameters): Promise<Channel[]> {
-    return this.service.list();
+  async list(request: FastifyRequest<{ Querystring: ChannelListQueryParameters, Params: BaseChannelsParameters }>): Promise<ChannelListResponse> {
+    const resources = await this.service.list(this.getExecutionContext(request));
+
+    return {
+      ...{
+        resources
+      },
+      ...(request.query.websockets && { websockets: getWorkspaceRooms(request.params, request.currentUser, request.query.mine) })
+    };
   }
 
-  async getChannel(params: ChannelParameters): Promise<Channel | void> {
-    return await this.service.get(params.id);
-  }
+  async delete(request: FastifyRequest<{ Params: ChannelParameters }>, reply: FastifyReply): Promise<ChannelDeleteResponse> {
+    const deleteResult = await this.service.delete(request.params.id, this.getExecutionContext(request));
 
-  async remove(params: ChannelParameters): Promise<boolean> {
-    const deleteResult = await this.service.delete(params.id);
+      if (deleteResult.deleted) {
+        reply.code(204);
 
-    return deleteResult.deleted;
-  }
+        return {
+          status: "success"
+        };
+      }
+
+      return {
+        status: "error"
+      };
+    }
 }

--- a/twake/backend/node/test/e2e/channels/channels.realtime.spec.ts
+++ b/twake/backend/node/test/e2e/channels/channels.realtime.spec.ts
@@ -3,6 +3,8 @@ import { ObjectId } from "mongodb";
 import io from "socket.io-client";
 import { Channel } from "../../../src/services/channels/entities";
 import ChannelServiceAPI from "../../../src/services/channels/provider";
+import { getChannelPath, getPublicRoomName } from "../../../src/services/channels/realtime";
+import { WorkspaceExecutionContext } from "../../../src/services/channels/types";
 import { TestPlatform, init } from "../setup";
 
 describe("The Channels Realtime feature", () => {
@@ -14,7 +16,7 @@ describe("The Channels Realtime feature", () => {
     platform = await init({
       services: ["websocket", "webserver", "channels", "auth", "database", "realtime"]
     });
-    socket = io.connect("http://localhost:3000", { path: "/ws" });
+    socket = io.connect("http://localhost:3000", { path: "/socket.io" });
   });
 
   afterEach(async () => {
@@ -37,7 +39,7 @@ describe("The Channels Realtime feature", () => {
         socket
           .emit("authenticate", { token: jwtToken })
           .on("authenticated", () => {
-            socket.emit("realtime:join", { name: "/channels", token: roomToken });
+            socket.emit("realtime:join", { name: getPublicRoomName({ workspace_id: workspaceId, company_id: companyId }), token: roomToken });
             socket.on("realtime:join:error", () => done(new Error("Should not occur")));
             socket.on("realtime:join:success", async () => {
               const response = await platform.app.inject({
@@ -89,13 +91,23 @@ describe("The Channels Realtime feature", () => {
           .emit("authenticate", { token: jwtToken })
           .on("authenticated", () => {
             socket.on("realtime:resource", event => {
+              if (event.action !== "deleted") {
+                // we can receive event when resource is created...
+                return;
+              }
+
               expect(event.type).toEqual("channel");
               expect(event.action).toEqual("deleted");
-              expect(event.path).toEqual(`/channels/${creationResult.entity.id}`);
+              expect(event.path).toEqual(
+                getChannelPath(
+                  { id: creationResult.entity.id } as Channel,
+                  { workspace: { workspace_id: workspaceId, company_id: companyId }} as WorkspaceExecutionContext
+                )
+              );
               expect(event.resource.id).toEqual(creationResult.entity.id);
               done();
             });
-            socket.emit("realtime:join", { name: "/channels", token: roomToken });
+            socket.emit("realtime:join", { name: getPublicRoomName({ workspace_id: workspaceId, company_id: companyId }), token: roomToken });
             socket.on("realtime:join:error", () => done(new Error("Should not occur")));
             socket.on("realtime:join:success", async () => {
               await platform.app.inject({

--- a/twake/backend/node/test/e2e/channels/channels.rest.spec.ts
+++ b/twake/backend/node/test/e2e/channels/channels.rest.spec.ts
@@ -4,6 +4,7 @@ import { TestPlatform, init } from "../setup";
 import { ChannelListResponse, ChannelGetResponse, ChannelCreateResponse, ChannelDeleteResponse } from "../../../src/services/channels/web/types";
 import ChannelServiceAPI from "../../../src/services/channels/provider";
 import { Channel } from "../../../src/services/channels/entities";
+import { getPrivateRoomName, getPublicRoomName } from "../../../src/services/channels/realtime";
 
 describe("The /api/channels API", () => {
   const url = "/api/channels";
@@ -116,7 +117,10 @@ describe("The /api/channels API", () => {
       const result = deserialize(ChannelListResponse, response.body);
 
       expect(response.statusCode).toBe(200);
-      expect(result.websockets.length).toEqual(2);
+      expect(result.websockets).toMatchObject([
+        { room: getPublicRoomName({ workspace_id: workspaceId, company_id: companyId }) },
+        { room: getPrivateRoomName({ workspace_id: workspaceId, company_id: companyId }, { id: "1" }) },
+      ]);
 
       done();
     });


### PR DESCRIPTION
With the help of the execution context, we will be able to push realtime updates to the right websocket rooms.
Also, this PR introduces a wrapper for the ChannelService implementation so that mongo and cassandra implementation does not have to deal with decorators.