### PR TITLE
↔️ Use websocket details for transport

### DIFF
--- a/twake/frontend/src/app/services/Collections/Collection.ts
+++ b/twake/frontend/src/app/services/Collections/Collection.ts
@@ -1,8 +1,6 @@
 import Storage from './Storage';
-import Collections from './Collections';
 import EventEmitter from './EventEmitter';
 import Resource from './Resource';
-import Transport from './Transport/Transport';
 import CollectionTransport from './Transport/CollectionTransport';
 
 /**
@@ -13,6 +11,7 @@ import CollectionTransport from './Transport/CollectionTransport';
 
 type GeneralOptions = {
   withoutBackend: boolean;
+  alwaysNotify: boolean;
 } & any;
 
 export default class Collection<G extends Resource<any>> {
@@ -69,8 +68,6 @@ export default class Collection<G extends Resource<any>> {
     this.updateLocalResource(mongoItem, item);
     this.eventEmitter.notify();
 
-    console.log('here insert', mongoItem);
-
     if (!options?.withoutBackend) {
       this.transport.upsert(this.resources[mongoItem.id]);
     }
@@ -95,6 +92,9 @@ export default class Collection<G extends Resource<any>> {
           this.transport.remove(resource);
         }
       }
+    }
+    if (options?.alwaysNotify) {
+      this.eventEmitter.notify();
     }
     return;
   }

--- a/twake/frontend/src/app/services/Collections/Collections.ts
+++ b/twake/frontend/src/app/services/Collections/Collections.ts
@@ -21,7 +21,7 @@ type Options = {
 };
 class Collections {
   private collections: { [key: string]: Collection<Resource<any>> } = {};
-  private options: Options = { transport: { rest: { url: '' }, socket: { url: '' } } };
+  private options: Options = { transport: {} };
   protected transport: Transport = new Transport();
 
   public setOptions(options: Options) {

--- a/twake/frontend/src/app/services/Collections/Transport/CollectionTransport.ts
+++ b/twake/frontend/src/app/services/Collections/Transport/CollectionTransport.ts
@@ -1,5 +1,5 @@
 import Collections, { Collection, Resource } from '../Collections';
-import Storage from '../Storage';
+import CollectionTransportSockets from './CollectionTransportSockets';
 
 type WebsocketEvent = { action: 'created' | 'updated' | 'deleted'; resource: any };
 type ServerAction = {
@@ -7,13 +7,16 @@ type ServerAction = {
   resourceId: string;
   options: any;
 };
+type WebsocketDefinition = {
+  room: string;
+};
 
 export default class CollectionTransport<G extends Resource<any>> {
+  private socketTransport: CollectionTransportSockets<G> = new CollectionTransportSockets<G>(this);
   private buffer: ServerAction[] = [];
-  private websocketBuffer: WebsocketEvent[] = [];
-  private httpUsed: number = 0;
+  httpUsed: number = 0;
 
-  constructor(private readonly collection: Collection<G>) {
+  constructor(readonly collection: Collection<G>) {
     //@ts-ignore
     window.CollectionTransport = this;
   }
@@ -22,44 +25,14 @@ export default class CollectionTransport<G extends Resource<any>> {
    * This collection is visible, transport must start
    */
   start() {
-    console.log('start listening to collection', this.collection.getPath());
-    setTimeout(() => {
-      Collections.getTransport()
-        .getSocket()
-        //TODO need to create a type for socket events
-        .join('/channels' /*this.collection.getPath()*/, async (event: WebsocketEvent) => {
-          this.websocketBuffer.push(event);
-          if (this.httpUsed === 0) this.flushWebsocketBuffer();
-        });
-    }, 1000);
+    this.socketTransport.start();
   }
 
   /**
    * This collection is not visible / used anymore, transport can stop
    */
   stop() {
-    console.log('stop listening to collection', this.collection.getPath());
-    Collections.getTransport().getSocket().leave(this.collection.getPath());
-  }
-
-  async onWebsocketEvent(action: string, resource: any) {
-    if (action === 'created' || action === 'updated') {
-      let localResource = await this.collection.findOne(resource.id);
-      if (!localResource) {
-        localResource = new (this.collection.getType())(resource);
-      }
-      localResource.setShared();
-      this.collection.upsert(localResource, {
-        withoutBackend: true,
-      });
-    }
-    if (action === 'deleted') {
-      console.log('delete', resource);
-      let localResource = await this.collection.findOne(resource.id);
-      this.collection.remove(localResource, {
-        withoutBackend: true,
-      });
-    }
+    this.socketTransport.stop();
   }
 
   async flushBuffer() {
@@ -69,7 +42,10 @@ export default class CollectionTransport<G extends Resource<any>> {
     for (let i = 0; i < buffer.length; i++) {
       try {
         if (buffer[i].action === 'create' || buffer[i].action === 'update') {
-          await this.callUpsert(await this.collection.findOne({ id: buffer[i].resourceId }));
+          const resource = await this.collection.findOne({ id: buffer[i].resourceId });
+          if (resource) {
+            await this.callUpsert(resource);
+          }
         }
         if (buffer[i].action === 'delete') {
           await this.callRemove(buffer[i].resourceId);
@@ -95,27 +71,26 @@ export default class CollectionTransport<G extends Resource<any>> {
     return true;
   }
 
-  flushWebsocketBuffer() {
-    const buffer = this.websocketBuffer;
-    this.websocketBuffer = [];
-    buffer.forEach(event => {
-      this.onWebsocketEvent(event.action, event.resource);
-    });
-  }
-
   lockHttp() {
     this.httpUsed++;
   }
   unlockHttp() {
     this.httpUsed--;
-    if (this.httpUsed === 0) this.flushWebsocketBuffer();
+    if (this.httpUsed === 0) this.socketTransport.flushWebsocketBuffer();
   }
 
   async get(options?: any) {
     this.lockHttp();
     try {
-      const result = await Collections.getTransport().getHttp().get(this.collection.getPath());
+      const result = await Collections.getTransport()
+        .getHttp()
+        .get(this.collection.getPath().replace(/\/$/, '') + '?websockets=1');
       this.unlockHttp();
+
+      if (result?.websockets) {
+        this.socketTransport.updateWebsocketInformation(result?.websockets);
+      }
+
       return result;
     } catch (err) {
       console.log(err);
@@ -125,7 +100,7 @@ export default class CollectionTransport<G extends Resource<any>> {
   }
 
   async upsert(resource: G) {
-    this.buffer = this.buffer.filter(item => item.resourceId != resource.id);
+    this.buffer = this.buffer.filter(item => item.resourceId !== resource.id);
 
     this.buffer.push({
       action: resource.state.persisted ? 'update' : 'create',
@@ -137,7 +112,7 @@ export default class CollectionTransport<G extends Resource<any>> {
   }
 
   async remove(resource: G) {
-    this.buffer = this.buffer.filter(item => item.resourceId != resource.id);
+    this.buffer = this.buffer.filter(item => item.resourceId !== resource.id);
 
     if (resource.state.persisted) {
       this.buffer.push({
@@ -155,15 +130,19 @@ export default class CollectionTransport<G extends Resource<any>> {
     try {
       const result = await Collections.getTransport()
         .getHttp()
-        .post(this.collection.getPath(), resource.data);
-
-      if (result?.resource) {
-        resource.setPersisted(true);
-        resource.data = Object.assign(resource.data, result?.resource);
-        await this.collection.upsert(resource, { withoutBackend: true });
-      } else {
-        //This resource is invalid, remove it
-        await this.collection.remove(resource, { withoutBackend: true });
+        .post(
+          this.collection.getPath().replace(/\/$/, resource.state.persisted ? '/' : ''),
+          resource.data,
+        );
+      if (!result?.offline) {
+        if (result?.resource) {
+          resource.setPersisted(true);
+          resource.data = Object.assign(resource.data, result?.resource);
+          await this.collection.upsert(resource, { withoutBackend: true });
+        } else {
+          //This resource is invalid, remove it
+          await this.collection.remove(resource, { withoutBackend: true });
+        }
       }
 
       this.unlockHttp();

--- a/twake/frontend/src/app/services/Collections/Transport/CollectionTransportSockets.ts
+++ b/twake/frontend/src/app/services/Collections/Transport/CollectionTransportSockets.ts
@@ -1,0 +1,100 @@
+import Collections, { Resource } from '../Collections';
+import CollectionTransport from './CollectionTransport';
+import { WebsocketEvents } from './TransportSocket';
+
+type WebsocketResourceEvent = {
+  action: 'created' | 'updated' | 'deleted' | 'realtime:join:success' | 'realtime:join:error';
+  resource: any;
+};
+type WebsocketJoinEvent = {
+  name: string;
+};
+type WebsocketDefinition = {
+  room: string;
+};
+
+export default class CollectionTransportSocket<G extends Resource<any>> {
+  private websocketBuffer: WebsocketResourceEvent[] = [];
+  private websocketRooms: WebsocketDefinition[] = [];
+  private joined: string[] = [];
+
+  constructor(private readonly transport: CollectionTransport<G>) {}
+
+  /**
+   * This collection is visible, transport must start
+   */
+  start() {
+    this.websocketRooms.forEach(definition => {
+      if (this.joined.indexOf(definition.room) < 0) {
+        Collections.getTransport()
+          .getSocket()
+          .join(
+            definition.room,
+            async (type: WebsocketEvents, event: WebsocketResourceEvent & WebsocketJoinEvent) => {
+              switch (type) {
+                case WebsocketEvents.Connected:
+                  this.joined = [];
+                  this.start();
+                  break;
+                case WebsocketEvents.JoinSuccess:
+                  this.joined.push(event.name);
+                  break;
+                case WebsocketEvents.JoinError:
+                  this.joined.splice(this.joined.indexOf(event.name), 1);
+                  console.log('Disconnected from ', event.name);
+                  break;
+                case WebsocketEvents.Resource:
+                  this.websocketBuffer.push(event as WebsocketResourceEvent);
+                  if (this.transport.httpUsed === 0) this.flushWebsocketBuffer();
+                  break;
+                default:
+                  console.warn('Not implemented: ', type, event);
+              }
+            },
+          );
+      }
+    });
+  }
+
+  /**
+   * This collection is not visible / used anymore, transport can stop
+   */
+  stop() {
+    this.joined.forEach(room => {
+      Collections.getTransport().getSocket().leave(room);
+    });
+  }
+
+  flushWebsocketBuffer() {
+    const buffer = this.websocketBuffer;
+    this.websocketBuffer = [];
+    buffer.forEach(event => {
+      this.onWebsocketResourceEvent(event.action, event.resource);
+    });
+  }
+
+  async updateWebsocketInformation(websockets: WebsocketDefinition[]) {
+    this.websocketRooms = websockets;
+    this.start();
+  }
+
+  async onWebsocketResourceEvent(action: string, resource: any) {
+    if (action === 'created' || action === 'updated') {
+      let localResource = await this.transport.collection.findOne(resource.id);
+      if (!localResource) {
+        localResource = new (this.transport.collection.getType())(resource);
+      }
+      localResource.setShared();
+      this.transport.collection.upsert(localResource, {
+        withoutBackend: true,
+      });
+    }
+    if (action === 'deleted') {
+      let localResource = await this.transport.collection.findOne({ id: resource.id });
+      this.transport.collection.remove(localResource, {
+        withoutBackend: true,
+        alwaysNotify: true, //Because the localDB can already have deleted the item from an other tab
+      });
+    }
+  }
+}

--- a/twake/frontend/src/app/services/Collections/Transport/Transport.ts
+++ b/twake/frontend/src/app/services/Collections/Transport/Transport.ts
@@ -1,4 +1,3 @@
-import Collections, { Collection, Resource } from '../Collections';
 import TransportHTTP from './TransportHTTP';
 import TransportSocket from './TransportSocket';
 
@@ -10,8 +9,6 @@ export default class Transport {
   };
   private readonly http: TransportHTTP = new TransportHTTP(this);
   private readonly socket: TransportSocket = new TransportSocket(this);
-
-  constructor() {}
 
   /** Transport API */
 

--- a/twake/frontend/src/app/services/Collections/Transport/TransportHTTP.ts
+++ b/twake/frontend/src/app/services/Collections/Transport/TransportHTTP.ts
@@ -1,11 +1,15 @@
-import Collections, { Collection, Resource } from '../Collections';
+import Collections from '../Collections';
 import Transport from './Transport';
 
 export default class TransportHTTP {
   constructor(private readonly transport: Transport) {}
 
   private async request(method: string, route: string, options: any) {
-    route = Collections.getOptions().transport?.rest?.url + route;
+    const prefix = Collections.getOptions().transport?.rest?.url;
+    if (!prefix) {
+      return { offline: true };
+    }
+    route = prefix + route;
 
     const response = await fetch(route, {
       method: method,

--- a/twake/frontend/src/app/services/CollectionsReact/Collections.ts
+++ b/twake/frontend/src/app/services/CollectionsReact/Collections.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'events';
 import OriginalCollections, {
   Collection as OriginalCollection,
   Resource as OriginalResource,

--- a/twake/frontend/src/app/services/CollectionsReact/__tests__/CollectionReact.test.tsx
+++ b/twake/frontend/src/app/services/CollectionsReact/__tests__/CollectionReact.test.tsx
@@ -15,9 +15,11 @@ class Message extends Resource<any> {
 
 const MessagesComponent = (props: { channelId: string }) => {
   const channelId = props.channelId;
-  const MessagesCollection = Collection.get(`/channels/${channelId}/messages/`, Message);
+  const messagesCollection = Collection.get(`/channels/${channelId}/messages/`, Message);
 
-  const messages = MessagesCollection.useWatcher(async () => await MessagesCollection.find()) || [];
+  const messages = messagesCollection.useWatcher(async () => await messagesCollection.find()) || [];
+
+  console.log(messages);
 
   return (
     <div>
@@ -30,7 +32,7 @@ const MessagesComponent = (props: { channelId: string }) => {
       <button
         id="add_button"
         onClick={() =>
-          MessagesCollection.insert(new Message({ content: 'Time is: ' + new Date().getTime() }))
+          messagesCollection.insert(new Message({ content: 'Time is: ' + new Date().getTime() }))
         }
       >
         Add
@@ -72,17 +74,17 @@ test('Test Observable linked to Collection', async () => {
   );
 
   const msg = new Message({ content: 'message_to_remove' });
-  collection.insert(msg);
+  await collection.insert(msg);
   await flushPromises();
   expect(component.find('#message_list').children().length).toBe(1);
   expect(component.find('#message_list').children().text()).toBe('message_to_remove');
 
   msg.setContent('message_to_remove_edited');
-  collection.update(msg);
+  await collection.update(msg);
   await flushPromises();
   expect(component.find('#message_list').children().text()).toBe('message_to_remove_edited');
 
-  collection.remove(msg);
+  await collection.remove(msg);
   await flushPromises();
   expect(component.find('#message_list').children().length).toBe(0);
 

--- a/twake/frontend/src/app/services/Observable/Observable.ts
+++ b/twake/frontend/src/app/services/Observable/Observable.ts
@@ -53,8 +53,7 @@ export default class Observable extends EventListener {
       if (changes.didChange) {
         //If things changed
         watcher.callback(
-          //Could be imporved ?
-          typeof changes.changes === 'object' && changes.changes?.constructor?.name != 'Array'
+          typeof changes.changes === 'object' && changes.changes?.constructor?.name !== 'Array'
             ? Object.assign(Object.create(Object.getPrototypeOf(changes.changes)), changes.changes)
             : changes.changes,
         );


### PR DESCRIPTION
- Use the websocket details from GET calls to initialise websockets
- Auto-rejoin websocket rooms on disconnection
- Offline mode with IndexedDb (fallback to MemoryDB) 
- If no configuration, no http request are done
- Apply linter to Collections and Observables