### PR TITLE
Fix compilation failure when building PHP Docker image

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: cd twake && mv docker-compose.yml.dist.tests docker-compose.yml
@@ -19,7 +19,7 @@ jobs:
         if: always()
         run: cd twake && docker-compose run -e DB_DRIVER=cassandra node npm run test
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: cd twake && mv docker-compose.yml.dist.tests docker-compose.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,19 +8,19 @@ on:
 
 jobs:
   build-nginx:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: cd twake && docker build -t twaketech/twake-nginx -f docker/twake-nginx/Dockerfile .
 
   build-php:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: cd twake && docker build -t twaketech/twake-php -f docker/twake-php/Dockerfile .
 
   build-node:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: cd twake/backend/node && docker build --target production -t twaketech/twake-node -f ../../docker/twake-node/Dockerfile .

--- a/.github/workflows/saas-update-backend.yml
+++ b/.github/workflows/saas-update-backend.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-php:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set env to develop
         if: endsWith(github.ref, '/develop')
@@ -31,7 +31,7 @@ jobs:
           tags: "${{ env.DOCKERTAG }}"
 
   deploy-node:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set env to develop
         if: endsWith(github.ref, '/develop')

--- a/.github/workflows/saas-update-front.yml
+++ b/.github/workflows/saas-update-front.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-frontend:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       FRONTEND_ENV: ${{secrets.FRONTEND_ENV}}
 
@@ -46,7 +46,7 @@ jobs:
 
   deploy-nginx:
     needs: build-frontend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     steps:
       - name: Set env to develop
@@ -72,7 +72,7 @@ jobs:
 
   deploy-saas:
     needs: deploy-nginx
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main'
 
     steps:

--- a/twake/docker/twake-nginx-php-only/Dockerfile
+++ b/twake/docker/twake-nginx-php-only/Dockerfile
@@ -1,5 +1,5 @@
 # nginx/Dockerfile
-FROM debian:jessie
+FROM debian:buster
 
 MAINTAINER Romaric Mourgues <romaric.mourgues@twakeapp.com>
 
@@ -21,19 +21,19 @@ RUN usermod -u 1000 www-data
 RUN wget https://dl.eff.org/certbot-auto
 RUN chmod a+x certbot-auto
 RUN apt-get update && apt-get install -y \
-  augeas-lenses binutils cpp cpp-4.9 dh-python gcc gcc-4.9 libasan1 libatomic1 \
-  libaugeas0 libc-dev-bin libc6-dev libcilkrts5 libcloog-isl4 libexpat1-dev \
-  libffi-dev libgcc-4.9-dev libgomp1 libisl10 libitm1 liblsan0 libmpc3 \
-  libmpdec2 libmpfr4 libpython-dev libpython-stdlib libpython2.7 \
+  augeas-lenses binutils cpp cpp-8 dh-python gcc gcc-8 libasan5 libatomic1 \
+  libaugeas0 libc-dev-bin libc6-dev libcilkrts5 libexpat1-dev \
+  libffi-dev libgcc-8-dev libgomp1 libisl19 libitm1 liblsan0 libmpc3 \
+  libmpdec2 libmpfr6 libpython-dev libpython-stdlib libpython2.7 \
   libpython2.7-dev libpython2.7-minimal libpython2.7-stdlib libpython3-stdlib \
-  libpython3.4-minimal libpython3.4-stdlib libquadmath0 libsqlite3-0 \
+  libpython3.7-minimal libpython3.7-stdlib libquadmath0 libsqlite3-0 \
   libssl-dev libtsan0 libubsan0 linux-libc-dev mime-support python \
-  python-chardet-whl python-colorama-whl python-dev python-distlib-whl \
-  python-html5lib-whl python-minimal python-pip-whl python-pkg-resources \
-  python-requests-whl python-setuptools-whl python-six-whl python-urllib3-whl \
+  python-chardet python-colorama python-dev python-distlib \
+  python-html5lib python-minimal python-pip-whl python-pkg-resources \
+  python-requests python-setuptools python-six python-urllib3 \
   python-virtualenv python2.7 python2.7-dev python2.7-minimal python3 \
-  python3-minimal python3-pkg-resources python3-virtualenv python3.4 \
-  python3.4-minimal virtualenv zlib1g-dev
+  python3-minimal python3-pkg-resources python3-virtualenv python3.7 \
+  python3.7-minimal virtualenv zlib1g-dev
 
 
 COPY docker/twake-nginx-php-only/entrypoint.sh /

--- a/twake/docker/twake-nginx/Dockerfile
+++ b/twake/docker/twake-nginx/Dockerfile
@@ -1,5 +1,5 @@
 # nginx/Dockerfile
-FROM debian:jessie
+FROM debian:buster
 
 MAINTAINER Romaric Mourgues <romaric.mourgues@twakeapp.com>
 
@@ -20,19 +20,19 @@ RUN usermod -u 1000 www-data
 RUN wget https://dl.eff.org/certbot-auto
 RUN chmod a+x certbot-auto
 RUN apt-get update && apt-get install -y \
-  augeas-lenses binutils cpp cpp-4.9 dh-python gcc gcc-4.9 libasan1 libatomic1 \
-  libaugeas0 libc-dev-bin libc6-dev libcilkrts5 libcloog-isl4 libexpat1-dev \
-  libffi-dev libgcc-4.9-dev libgomp1 libisl10 libitm1 liblsan0 libmpc3 \
-  libmpdec2 libmpfr4 libpython-dev libpython-stdlib libpython2.7 \
+  augeas-lenses binutils cpp cpp-8 dh-python gcc gcc-8 libasan5 libatomic1 \
+  libaugeas0 libc-dev-bin libc6-dev libcilkrts5 libexpat1-dev \
+  libffi-dev libgcc-8-dev libgomp1 libisl19 libitm1 liblsan0 libmpc3 \
+  libmpdec2 libmpfr6 libpython-dev libpython-stdlib libpython2.7 \
   libpython2.7-dev libpython2.7-minimal libpython2.7-stdlib libpython3-stdlib \
-  libpython3.4-minimal libpython3.4-stdlib libquadmath0 libsqlite3-0 \
+  libpython3.7-minimal libpython3.7-stdlib libquadmath0 libsqlite3-0 \
   libssl-dev libtsan0 libubsan0 linux-libc-dev mime-support python \
-  python-chardet-whl python-colorama-whl python-dev python-distlib-whl \
-  python-html5lib-whl python-minimal python-pip-whl python-pkg-resources \
-  python-requests-whl python-setuptools-whl python-six-whl python-urllib3-whl \
+  python-chardet python-colorama python-dev python-distlib \
+  python-html5lib python-minimal python-pip-whl python-pkg-resources \
+  python-requests python-setuptools python-six python-urllib3 \
   python-virtualenv python2.7 python2.7-dev python2.7-minimal python3 \
-  python3-minimal python3-pkg-resources python3-virtualenv python3.4 \
-  python3.4-minimal virtualenv zlib1g-dev
+  python3-minimal python3-pkg-resources python3-virtualenv python3.7 \
+  python3.7-minimal virtualenv zlib1g-dev
 
 
 ADD docker/twake-nginx/site.conf /etc/nginx/sites-enabled/site
@@ -41,7 +41,7 @@ ADD docker/twake-nginx/nginx.conf /etc/nginx/nginx.conf
 # Install frontend
 RUN apt-get update
 RUN apt-get -y install curl
-RUN apt-get -y install apt-transport-https ca-certificates
+RUN apt-get -y install apt-transport-https ca-certificates apt-utils gnupg
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update

--- a/twake/docker/twake-php/Dockerfile
+++ b/twake/docker/twake-php/Dockerfile
@@ -89,7 +89,7 @@ RUN git clone https://github.com/datastax/php-driver.git /usr/src/datastax-php-d
 # Install PHP extensions
 RUN docker-php-ext-install zip mbstring intl opcache bcmath && \
     echo extension=bcmath.so > /usr/local/etc/php/conf.d/docker-php-ext-bcmath.ini && \
-    pecl install xdebug && \
+    apt-get install -y php5-xdebug && \
     echo zend_extension=xdebug.so > /usr/local/etc/php/conf.d/xdebug.ini && \
     pecl install apcu-5.1.5 && \
     echo extension=apcu.so > /usr/local/etc/php/conf.d/apcu.ini && \

--- a/twake/frontend/package.json
+++ b/twake/frontend/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "dev:start": "craco start",
     "dev:test": "craco test",
-    "dev:build": "CI=false craco build",
+    "dev:build": "CI=false craco --max_old_space_size=4096 build",
     "dev:prettier": "prettier --write src/",
     "dev:linter": "eslint src/",
     "start": "craco start",
     "test": "CI=true craco test",
-    "build": "scripts/build-version.sh patch && CI=false craco build",
+    "build": "scripts/build-version.sh patch && CI=false craco --max_old_space_size=4096 build",
     "change-version": "scripts/build-version.sh"
   },
   "eslintConfig": {


### PR DESCRIPTION
The main goal of this PR is to be able to build the Docker image on latest release of Debian (Buster) & Ubuntu (20.04).

The upgrade of the version used in the Github Actions is to follow those supported versions.  
Warning: Github Action `latest` tag for Ubuntu is wrong (18.04 instead of 20.04)