### PR TITLE
#727 Notify users in threads

### DIFF
--- a/twake/backend/node/src/core/platform/services/database/services/orm/connectors/cassandra/cassandra.ts
+++ b/twake/backend/node/src/core/platform/services/database/services/orm/connectors/cassandra/cassandra.ts
@@ -311,6 +311,8 @@ export class CassandraConnector extends AbstractConnector<
             .join(", ")})`;
         }
 
+        logger.debug(`service.database.orm.upsert - Query: "${query}"`);
+
         promises.push(
           new Promise(resolve => {
             try {

--- a/twake/backend/node/src/services/notifications/entities/channel-thread-users.ts
+++ b/twake/backend/node/src/services/notifications/entities/channel-thread-users.ts
@@ -4,7 +4,7 @@ import { Column, Entity } from "../../../core/platform/services/database/service
 
 export const TYPE = "channel_thread_users";
 @Entity(TYPE, {
-  primaryKey: [["company_id", "channel_id", "thread_id"]],
+  primaryKey: [["company_id", "channel_id", "thread_id"], "user_id"],
   type: TYPE,
 })
 export class ChannelThreadUsers {

--- a/twake/backend/node/src/services/notifications/services/engine/processors/new-channel-message/index.ts
+++ b/twake/backend/node/src/services/notifications/services/engine/processors/new-channel-message/index.ts
@@ -29,6 +29,7 @@ export class NewChannelMessageProcessor
     logger.info(
       `${this.name} - Processing notification for message ${message.thread_id}/${message.id} in channel ${message.channel_id}`,
     );
+    logger.debug(`${this.name} - Notification message ${JSON.stringify(message)}`);
 
     try {
       const usersToNotify = await this.getUsersToNotify(message);
@@ -74,6 +75,7 @@ export class NewChannelMessageProcessor
     const isAllOrHereMention = this.isAllOrHereMention(message);
 
     const users: ChannelThreadUsers[] = [
+      // message sender is a user in the thread
       ...[
         getChannelThreadUsersInstance({
           company_id: message.company_id,
@@ -82,6 +84,8 @@ export class NewChannelMessageProcessor
           user_id: message.sender,
         }),
       ],
+
+      // mentionned users are users in the thread
       ...(message?.mentions?.users?.length
         ? message.mentions.users.map(user_id =>
             getChannelThreadUsersInstance({
@@ -97,6 +101,7 @@ export class NewChannelMessageProcessor
     await this.service.channelThreads.bulkSave(users);
 
     if (isNewThread || isDirect || isAllOrHereMention) {
+      //get the channel level preferences
       channelPreferencesForUsers = (
         await this.service.channelPreferences.getChannelPreferencesForUsers({
           company_id: message.company_id,
@@ -104,6 +109,7 @@ export class NewChannelMessageProcessor
         })
       ).getEntities();
     } else {
+      // get the preferences of the users involved in the thread
       channelPreferencesForUsers = await this.getAllInvolvedUsersPreferences({
         channel_id: message.channel_id,
         company_id: message.company_id,
@@ -118,34 +124,42 @@ export class NewChannelMessageProcessor
     message: MessageNotification,
     membersPreferences: ChannelMemberNotificationPreference[],
   ): ChannelMemberNotificationPreference[] {
+    logger.debug(`${this.name} - Filter members ${JSON.stringify(membersPreferences)}`);
     const isAllOrHere = this.isAllOrHereMention(message);
+    return (
+      membersPreferences
+        // 1. Remove the ones which does not want any notification (preference === NONE)
+        .filter(preference => preference.preferences !== ChannelMemberNotificationLevel.NONE)
+        //2. Remove the sender
+        .filter(preference => String(preference.user_id) !== String(message.sender))
+        // 3. Filter based on truth table based on user preferences and current message
+        .filter(memberPreference => {
+          const userIsMentionned = this.userIsMentionned(memberPreference.user_id, message);
 
-    // 1. Remove the ones which does not want any notification (preference === NONE)
-    const result = membersPreferences
-      .filter(preference => preference.preferences !== ChannelMemberNotificationLevel.NONE)
-      //2. Remove the sender
-      .filter(preference => preference.user_id + "" !== message.sender + "");
+          const truthTable = [
+            // all
+            memberPreference.preferences === ChannelMemberNotificationLevel.ALL,
+            // mentions
+            memberPreference.preferences === ChannelMemberNotificationLevel.MENTIONS &&
+              (isAllOrHere || userIsMentionned),
+            // me
+            memberPreference.preferences === ChannelMemberNotificationLevel.ME && userIsMentionned,
+          ];
 
-    // 3. Filter based on truth table based on user preferences and current message
-    return result.filter(memberPreference => {
-      const userIsMentionned = this.userIsMentionned(memberPreference.user_id, message);
+          logger.debug(
+            `${this.name} - ${
+              memberPreference.user_id
+            } truth table [all, mentions, me] : ${JSON.stringify(truthTable)}`,
+          );
 
-      const truthTable = [
-        // all
-        memberPreference.preferences === ChannelMemberNotificationLevel.ALL,
-        // mentions
-        memberPreference.preferences === ChannelMemberNotificationLevel.MENTIONS &&
-          (isAllOrHere || userIsMentionned),
-        // me
-        memberPreference.preferences === ChannelMemberNotificationLevel.ME && userIsMentionned,
-      ];
-
-      return truthTable.includes(true);
-    });
+          return truthTable.includes(true);
+        })
+    );
   }
 
   /**
    * When message is a response in a thread, get all the users involved in the thread
+   * ie the ones who where initially mentionned, mentionned in children messages, and the ones who replied
    */
   protected async getAllInvolvedUsersPreferences(thread: {
     company_id: string;
@@ -176,6 +190,6 @@ export class NewChannelMessageProcessor
   }
 
   private userIsMentionned(user: string, message: MessageNotification) {
-    return message?.mentions?.users?.includes(user + "");
+    return message?.mentions?.users?.includes(String(user));
   }
 }

--- a/twake/backend/node/src/services/notifications/services/preferences/service.ts
+++ b/twake/backend/node/src/services/notifications/services/preferences/service.ts
@@ -12,7 +12,7 @@ import {
 import { DatabaseServiceAPI } from "../../../../core/platform/services/database/api";
 import { ChannelMemberPreferencesServiceAPI } from "../../api";
 import Repository from "../../../../core/platform/services/database/services/orm/repository/repository";
-import { TwakeContext } from "../../../../core/platform/framework";
+import { logger, TwakeContext } from "../../../../core/platform/framework";
 import { NotificationPubsubService } from "./pubsub";
 
 const TYPE = "channel_members_notification_preferences";
@@ -96,6 +96,11 @@ export class ChannelMemberPreferencesService implements ChannelMemberPreferences
       lessThan: number;
     },
   ): Promise<ListResult<ChannelMemberNotificationPreference>> {
+    logger.debug(
+      `ChannelMemberPreferenceService - Get Channel preferences for users ${JSON.stringify(
+        users,
+      )} with lastRead < ${lastRead?.lessThan}`,
+    );
     const result = await this.repository.find({ ...channelAndCompany, ...{ user_id: users } }, {});
 
     if (result.getEntities().length > 0 && lastRead && lastRead.lessThan) {
@@ -103,6 +108,12 @@ export class ChannelMemberPreferencesService implements ChannelMemberPreferences
         return entity.last_read < lastRead.lessThan;
       });
     }
+
+    logger.debug(
+      `ChannelMemberPreferenceService - Result ${JSON.stringify(
+        result.getEntities().map(preference => preference.user_id),
+      )}`,
+    );
 
     return result;
   }

--- a/twake/backend/node/test/unit/services/notifications/services/engine/processors/new-channel-message/index.test.ts
+++ b/twake/backend/node/test/unit/services/notifications/services/engine/processors/new-channel-message/index.test.ts
@@ -60,7 +60,7 @@ describe("The NewChannelMessageProcessor class", () => {
       workspace_id,
       channel_id,
       id: "id",
-      thread_id,
+      thread_id: "thread_id",
       sender: "sender",
       mentions: {
         users: [],
@@ -387,7 +387,7 @@ describe("The NewChannelMessageProcessor class", () => {
           {
             company_id: message.company_id,
             channel_id: message.channel_id,
-            thread_id: message.id,
+            thread_id: message.thread_id,
             user_id: message.sender,
           },
         ]);
@@ -399,7 +399,7 @@ describe("The NewChannelMessageProcessor class", () => {
         done();
       });
 
-      it("without mentions, should get the preferences for all members involved and return only the ones who want to be notified", async done => {
+      it("without mentions, should get the preferences for all members involved and return only the ones with preference !== NONE", async done => {
         const message = getMessage();
         setUsersInThread(["1", "2", "3", "4"]);
         setThreadResponsePreferences();
@@ -410,7 +410,7 @@ describe("The NewChannelMessageProcessor class", () => {
           {
             company_id: message.company_id,
             channel_id: message.channel_id,
-            thread_id: message.id,
+            thread_id: message.thread_id,
             user_id: message.sender,
           },
         ]);
@@ -418,7 +418,7 @@ describe("The NewChannelMessageProcessor class", () => {
         expect(service.channelThreads.getUsersInThread).toBeCalled;
         expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledTimes(1);
 
-        expect(result.mentions.users).toEqual(["1"]);
+        expect(result.mentions.users).toEqual(["1", "2", "3"]);
         done();
       });
 
@@ -434,31 +434,31 @@ describe("The NewChannelMessageProcessor class", () => {
           {
             company_id: message.company_id,
             channel_id: message.channel_id,
-            thread_id: message.id,
+            thread_id: message.thread_id,
             user_id: message.sender,
           },
           {
             company_id: message.company_id,
             channel_id: message.channel_id,
-            thread_id: message.id,
+            thread_id: message.thread_id,
             user_id: "1",
           },
           {
             company_id: message.company_id,
             channel_id: message.channel_id,
-            thread_id: message.id,
+            thread_id: message.thread_id,
             user_id: "2",
           },
           {
             company_id: message.company_id,
             channel_id: message.channel_id,
-            thread_id: message.id,
+            thread_id: message.thread_id,
             user_id: "3",
           },
           {
             company_id: message.company_id,
             channel_id: message.channel_id,
-            thread_id: message.id,
+            thread_id: message.thread_id,
             user_id: "4",
           },
         ]);

--- a/twake/backend/node/test/unit/services/notifications/services/engine/processors/new-channel-message/index.test.ts
+++ b/twake/backend/node/test/unit/services/notifications/services/engine/processors/new-channel-message/index.test.ts
@@ -150,13 +150,10 @@ describe("The NewChannelMessageProcessor class", () => {
 
         expect(service.channelThreads.getUsersInThread).not.toBeCalled;
         expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledTimes(1);
-        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith(
-          {
-            company_id: message.company_id,
-            channel_id: message.channel_id,
-          },
-          [],
-        );
+        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith({
+          company_id: message.company_id,
+          channel_id: message.channel_id,
+        });
 
         expect(result).toBeUndefined();
         done();
@@ -179,13 +176,10 @@ describe("The NewChannelMessageProcessor class", () => {
 
         expect(service.channelThreads.getUsersInThread).not.toBeCalled;
         expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledTimes(1);
-        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith(
-          {
-            company_id: message.company_id,
-            channel_id: message.channel_id,
-          },
-          [],
-        );
+        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith({
+          company_id: message.company_id,
+          channel_id: message.channel_id,
+        });
 
         expect(result.mentions.users).toEqual(["1"]);
         done();
@@ -287,13 +281,10 @@ describe("The NewChannelMessageProcessor class", () => {
 
         expect(service.channelThreads.getUsersInThread).not.toBeCalled;
         expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledTimes(1);
-        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith(
-          {
-            company_id: message.company_id,
-            channel_id: message.channel_id,
-          },
-          [],
-        );
+        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith({
+          company_id: message.company_id,
+          channel_id: message.channel_id,
+        });
 
         expect(result.mentions.users).toEqual(["1", "2", "3"]);
         done();
@@ -403,13 +394,6 @@ describe("The NewChannelMessageProcessor class", () => {
 
         expect(service.channelThreads.getUsersInThread).toBeCalled;
         expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledTimes(1);
-        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith(
-          {
-            company_id: message.company_id,
-            channel_id: message.channel_id,
-          },
-          ["1", "2", "3", "4"],
-        );
 
         expect(result).toBeUndefined();
         done();
@@ -433,13 +417,6 @@ describe("The NewChannelMessageProcessor class", () => {
 
         expect(service.channelThreads.getUsersInThread).toBeCalled;
         expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledTimes(1);
-        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith(
-          {
-            company_id: message.company_id,
-            channel_id: message.channel_id,
-          },
-          ["1", "2", "3", "4"],
-        );
 
         expect(result.mentions.users).toEqual(["1"]);
         done();
@@ -488,14 +465,6 @@ describe("The NewChannelMessageProcessor class", () => {
 
         expect(service.channelThreads.getUsersInThread).toBeCalled;
         expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledTimes(1);
-        expect(service.channelPreferences.getChannelPreferencesForUsers).toBeCalledWith(
-          {
-            company_id: message.company_id,
-            channel_id: message.channel_id,
-          },
-          ["1", "2", "3", "4"],
-        );
-
         expect(result.mentions.users).toEqual(["1", "2", "3"]);
         done();
       });


### PR DESCRIPTION
To fix, drop the `channel_thread_users` table and recreate it by restarting the node backend