### PR TITLE
WIP: Use Keystone v3 as Openstack identity service

### DIFF
--- a/twake/backend/core/app/Configuration/Parameters.php.dist
+++ b/twake/backend/core/app/Configuration/Parameters.php.dist
@@ -70,19 +70,20 @@ class Parameters extends \Common\Configuration
               "openstack" => [
                   "use" => false,
                   "project_id" => "",
-                  "auth_url" => "https//auth.cloud.ovh.net/v2.0",
+                  "auth_url" => "https//auth.cloud.ovh.net/v3",
                   "buckets_prefix" => "",
                   "buckets" => [
                       "fr" => [
                           "public" => "",
                           "private" => "",
                           "region" => "SBG5"
-                      ],
-                      "user" => [
-                          "id" => "",
-                          "password" => ""
                       ]
                   ],
+                  "user" => [
+                      "id" => "",
+                      "password" => "",
+                      "domain_name" => "default"
+                  ]
               ],
               "S3" => [
                   "base_url" => "http//127.0.0.1:9000",

--- a/twake/backend/core/src/Twake/Drive/Services/Storage/Adapter_OpenStack.php
+++ b/twake/backend/core/src/Twake/Drive/Services/Storage/Adapter_OpenStack.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Stream;
 use OpenStack\Common\Transport\Utils as TransportUtils;
-use OpenStack\Identity\v2\Service;
+use OpenStack\Identity\v3\Service;
 use OpenStack\OpenStack;
 use Twake\Drive\Entity\DriveFile;
 use Twake\Drive\Entity\UploadState;
@@ -39,6 +39,7 @@ class Adapter_OpenStack implements AdapterInterface
         $this->openstack_buckets_prefix = $openstack["buckets_prefix"];
         $this->openstack_credentials_key = $openstack["user"]["id"];
         $this->openstack_credentials_secret = $openstack["user"]["password"];
+        $this->openstack_domain_name = $openstack["user"]["domain_name"];
         $this->openstack_project_id = $openstack["project_id"];
         $this->openstack_auth_url = $openstack["auth_url"];
 
@@ -67,9 +68,16 @@ class Adapter_OpenStack implements AdapterInterface
         $this->openstack = new OpenStack([
             'authUrl' => $this->openstack_auth_url,
             'region' => $this->openstack_region_id,
-            'tenantId' => $this->openstack_project_id,
-            'username' => $this->openstack_credentials_key . "",
-            'password' => $this->openstack_credentials_secret,
+            'user' => [
+                'name' => $this->openstack_credentials_key,
+                'password' => $this->openstack_credentials_secret,
+                'domain'   => [ 'id' => $this->openstack_domain_name ]
+            ],
+            'scope'   => [
+                'project' => [
+                    'id' => $this->openstack_project_id
+                ]
+            ],
             'identityService' => Service::factory($httpClient)
         ]);
 


### PR DESCRIPTION
Please @RomaricMourgues  have a look.

We need such modification in order to access OVH object storages (v2 is no more supported by them).